### PR TITLE
Fix for Flutter 1.19

### DIFF
--- a/lib/src/custom_widget.dart
+++ b/lib/src/custom_widget.dart
@@ -40,9 +40,7 @@ class _BeforeAfterState extends State<BeforeAfter> {
       alignment: Alignment.center,
       children: <Widget>[
         Padding(
-          padding: widget.isVertical
-              ? const EdgeInsets.symmetric(vertical: 24.0)
-              : const EdgeInsets.symmetric(horizontal: 24.0),
+          padding: widget.isVertical ? const EdgeInsets.symmetric(vertical: 24.0) : const EdgeInsets.symmetric(horizontal: 24.0),
           child: SizedImage(
             widget.afterImage,
             widget.imageHeight,
@@ -51,13 +49,9 @@ class _BeforeAfterState extends State<BeforeAfter> {
           ),
         ),
         Padding(
-          padding: widget.isVertical
-              ? const EdgeInsets.symmetric(vertical: 24.0)
-              : const EdgeInsets.symmetric(horizontal: 24.0),
+          padding: widget.isVertical ? const EdgeInsets.symmetric(vertical: 24.0) : const EdgeInsets.symmetric(horizontal: 24.0),
           child: ClipPath(
-            clipper: widget.isVertical
-                ? RectClipperVertical(_clipFactor)
-                : RectClipper(_clipFactor),
+            clipper: widget.isVertical ? RectClipperVertical(_clipFactor) : RectClipper(_clipFactor),
             child: SizedImage(
               widget.beforeImage,
               widget.imageHeight,
@@ -71,22 +65,19 @@ class _BeforeAfterState extends State<BeforeAfter> {
             data: SliderThemeData(
               trackHeight: 0.0,
               overlayColor: widget.overlayColor,
-              thumbShape:
-                  CustomThumbShape(widget.thumbRadius, widget.thumbColor),
+              thumbShape: CustomThumbShape(widget.thumbRadius, widget.thumbColor),
             ),
             child: widget.isVertical
                 ? RotatedBox(
                     quarterTurns: 1,
                     child: Slider(
                       value: _clipFactor,
-                      onChanged: (double factor) =>
-                          setState(() => this._clipFactor = factor),
+                      onChanged: (double factor) => setState(() => this._clipFactor = factor),
                     ),
                   )
                 : Slider(
                     value: _clipFactor,
-                    onChanged: (double factor) =>
-                        setState(() => this._clipFactor = factor),
+                    onChanged: (double factor) => setState(() => this._clipFactor = factor),
                   ),
           ),
         ),
@@ -99,10 +90,7 @@ class SizedImage extends StatelessWidget {
   final Widget _image;
   final double _height, _width, _imageCornerRadius;
 
-  const SizedImage(
-      this._image, this._height, this._width, this._imageCornerRadius,
-      {Key key})
-      : super(key: key);
+  const SizedImage(this._image, this._height, this._width, this._imageCornerRadius, {Key key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -169,9 +157,6 @@ class CustomThumbShape extends SliderComponentShape {
       paint,
     );
 
-    canvas.drawRect(
-        Rect.fromCenter(
-            center: center, width: 4.0, height: parentBox.size.height),
-        paint);
+    canvas.drawRect(Rect.fromCenter(center: center, width: 4.0, height: parentBox.size.height), paint);
   }
 }


### PR DESCRIPTION
Error: The method 'CustomThumbShape.paint' has fewer named arguments than those of overridden method 'SliderComponentShape.paint'.