### PR TITLE
- zoom and pan image

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.21'
     repositories {
         google()
         mavenCentral()

--- a/example/ios/Flutter/flutter_export_environment.sh
+++ b/example/ios/Flutter/flutter_export_environment.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 # This is a generated file; do not edit or check into version control.
-export "FLUTTER_ROOT=/home/andrey/snap/flutter/common/flutter"
-export "FLUTTER_APPLICATION_PATH=/home/andrey/FlutterProjects/before_after/example"
+export "FLUTTER_ROOT=C:\Users\yuran\Documents\Flutter\flutter"
+export "FLUTTER_APPLICATION_PATH=C:\Users\yuran\AndroidStudioProjects\before_after\example"
 export "COCOAPODS_PARALLEL_CODE_SIGN=true"
-export "FLUTTER_TARGET=lib/main.dart"
+export "FLUTTER_TARGET=lib\main.dart"
 export "FLUTTER_BUILD_DIR=build"
 export "FLUTTER_BUILD_NAME=1.0.0"
 export "FLUTTER_BUILD_NUMBER=1"

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -40,14 +40,14 @@ class MyHomePage extends StatelessWidget {
                 afterImage: Image.asset('assets/before.jpg'),
               ),
             ),
-            Expanded(
-              flex: 1,
-              child: BeforeAfter(
-                beforeImage: Image.asset('assets/after.jpg'),
-                afterImage: Image.asset('assets/before.jpg'),
-                isVertical: true,
-              ),
-            ),
+            // Expanded(
+            //   flex: 1,
+            //   child: BeforeAfter(
+            //     beforeImage: Image.asset('assets/after.jpg'),
+            //     afterImage: Image.asset('assets/before.jpg'),
+            //     isVertical: true,
+            //   ),
+            // ),
           ],
         ),
       ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   before_after:
     dependency: "direct main"
     description:
@@ -28,7 +28,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -94,7 +94,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -155,7 +162,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:
@@ -169,6 +176,6 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"

--- a/lib/src/custom_widget.dart
+++ b/lib/src/custom_widget.dart
@@ -7,19 +7,19 @@ class BeforeAfter extends StatefulWidget {
   final double? imageHeight;
   final double? imageWidth;
   final double imageCornerRadius;
-  final Color thumbColor;
+  late Color thumbColor;
   final double thumbRadius;
   final Color? overlayColor;
   final bool isVertical;
 
-  const BeforeAfter({
+  BeforeAfter({
     Key? key,
     required this.beforeImage,
     required this.afterImage,
     this.imageHeight,
     this.imageWidth,
     this.imageCornerRadius = 8.0,
-    this.thumbColor = Colors.white,
+    this.thumbColor = Colors.green,
     this.thumbRadius = 16.0,
     this.overlayColor,
     this.isVertical = false,
@@ -31,61 +31,98 @@ class BeforeAfter extends StatefulWidget {
 
 class _BeforeAfterState extends State<BeforeAfter> {
   double _clipFactor = 0.5;
+  var _ignoreSlider = false;
 
   @override
   Widget build(BuildContext context) {
     return Stack(
-      alignment: Alignment.center,
-      children: <Widget>[
-        Padding(
-          padding: widget.isVertical
-              ? const EdgeInsets.symmetric(vertical: 24.0)
-              : const EdgeInsets.symmetric(horizontal: 24.0),
-          child: SizedImage(
-            widget.afterImage,
-            widget.imageHeight,
-            widget.imageWidth,
-            widget.imageCornerRadius,
-          ),
-        ),
-        Padding(
-          padding: widget.isVertical
-              ? const EdgeInsets.symmetric(vertical: 24.0)
-              : const EdgeInsets.symmetric(horizontal: 24.0),
-          child: ClipPath(
-            clipper: widget.isVertical
-                ? RectClipperVertical(_clipFactor)
-                : RectClipper(_clipFactor),
-            child: SizedImage(
-              widget.beforeImage,
-              widget.imageHeight,
-              widget.imageWidth,
-              widget.imageCornerRadius,
-            ),
-          ),
-        ),
-        Positioned.fill(
-          child: SliderTheme(
-            data: SliderThemeData(
-              trackHeight: 0.0,
-              overlayColor: widget.overlayColor,
-              thumbShape:
-                  CustomThumbShape(widget.thumbRadius, widget.thumbColor),
-            ),
-            child: widget.isVertical
-                ? RotatedBox(
-                    quarterTurns: 1,
-                    child: Slider(
-                      value: _clipFactor,
-                      onChanged: (double factor) =>
-                          setState(() => this._clipFactor = factor),
-                    ),
-                  )
-                : Slider(
-                    value: _clipFactor,
-                    onChanged: (double factor) =>
-                        setState(() => this._clipFactor = factor),
+      children: [
+        GestureDetector(
+          onLongPress: (() {
+            setState(() {
+              _ignoreSlider = false;
+              widget.thumbColor = Colors.green;
+              print(_ignoreSlider);
+            });
+          }),
+          child: InteractiveViewer(
+            clipBehavior: Clip.none,
+            minScale: 1,
+            maxScale: 4,
+            child: Stack(
+              alignment: Alignment.center,
+              children: <Widget>[
+                Padding(
+                  padding: widget.isVertical
+                      ? const EdgeInsets.symmetric(vertical: 24.0)
+                      : const EdgeInsets.symmetric(horizontal: 24.0),
+                  child: SizedImage(
+                    widget.afterImage,
+                    widget.imageHeight,
+                    widget.imageWidth,
+                    widget.imageCornerRadius,
                   ),
+                ),
+                Padding(
+                  padding: widget.isVertical
+                      ? const EdgeInsets.symmetric(vertical: 24.0)
+                      : const EdgeInsets.symmetric(horizontal: 24.0),
+                  child: ClipPath(
+                    clipper: widget.isVertical
+                        ? RectClipperVertical(_clipFactor)
+                        : RectClipper(_clipFactor),
+                    child: SizedImage(
+                      widget.beforeImage,
+                      widget.imageHeight,
+                      widget.imageWidth,
+                      widget.imageCornerRadius,
+                    ),
+                  ),
+                ),
+                Positioned.fill(
+                  child: GestureDetector(
+                    onLongPress: (){
+                      widget.thumbColor = Colors.grey;
+                      _ignoreSlider = true;
+                      print(_ignoreSlider);
+                    },
+                    child: IgnorePointer(
+                      ignoring: _ignoreSlider,
+                      child: SliderTheme(
+                        data: SliderThemeData(
+                          trackHeight: 0.0,
+                          overlayColor: widget.overlayColor,
+                          thumbShape:
+                          CustomThumbShape(widget.thumbRadius, widget.thumbColor),
+                        ),
+                        child: widget.isVertical
+                            ? RotatedBox(
+                          quarterTurns: 1,
+                          child: Slider(
+                            value: _clipFactor,
+                            onChanged: (double factor) =>
+                                setState(() {
+                                  double diff = (factor - _clipFactor).abs();
+                                  if(diff<=0.07) {
+                                    _clipFactor = factor;
+                                  }}),
+                          ),
+                        )
+                            : Slider(
+                          value: _clipFactor,
+                          onChanged: (double factor) =>
+                              setState(() {
+                                double diff = (factor - _clipFactor).abs();
+                                if(diff<=0.07) {
+                                  _clipFactor = factor;
+                                }}),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       ],
@@ -129,15 +166,15 @@ class CustomThumbShape extends SliderComponentShape {
   @override
   void paint(PaintingContext context, Offset center,
       {Animation<double>? activationAnimation,
-      Animation<double>? enableAnimation,
-      bool? isDiscrete,
-      TextPainter? labelPainter,
-      required RenderBox parentBox,
-      SliderThemeData? sliderTheme,
-      TextDirection? textDirection,
-      double? value,
-      double? textScaleFactor,
-      Size? sizeWithOverflow}) {
+        Animation<double>? enableAnimation,
+        bool? isDiscrete,
+        TextPainter? labelPainter,
+        required RenderBox parentBox,
+        SliderThemeData? sliderTheme,
+        TextDirection? textDirection,
+        double? value,
+        double? textScaleFactor,
+        Size? sizeWithOverflow}) {
     final Canvas canvas = context.canvas;
 
     final Paint paint = Paint()

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -66,7 +66,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -127,7 +134,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:
@@ -141,6 +148,6 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
- switch when to zoom/slide by longpressing thumb
- Note: thumb also gets scaled when scaling image (couldn't find a way to make it static)
- there's a delay when switching to zoom/slide
- changed compileSdkVersion and kotlin version, it was giving me kotlin problems for running on emulator
- changed main.dart, because I found it better to test with only one before_after widget